### PR TITLE
Update routing_controller.dart

### DIFF
--- a/auto_route/lib/src/router/controller/routing_controller.dart
+++ b/auto_route/lib/src/router/controller/routing_controller.dart
@@ -691,7 +691,11 @@ class TabsRouter extends RoutingController {
   @optionalTypeArgs
   Future<bool> pop<T extends Object?>([T? result]) {
     if (homeIndex != -1 && _activeIndex != homeIndex) {
-      setActiveIndex(homeIndex);
+      if(previousIndex != null && previousIndex != homeIndex) {
+        setActiveIndex(previousIndex!);
+      } else {
+        setActiveIndex(homeIndex);
+      }
       return SynchronousFuture<bool>(true);
     } else if (_parent != null) {
       return _parent!.pop<T>(result);


### PR DESCRIPTION
Solves #1789
This commit will affect AutoTabsRouter path stacking. If the user click on the back button and activeIndex is not homeIndex, then pops to previous active tab not homeIndex.